### PR TITLE
Remove private repository dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,10 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 wasm-bindgen = "0.2.63"
-uplc = { git = "https://github.com/zmrocze/aiken", rev = "b28ead25eb3d8ba758d4b8abb2f15f3b00b382a7" }
-pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "50b9dc47028001d5790a3b283ca4cbe9dc98f100" }
-pallas-codec = { git = "https://github.com/txpipe/pallas", rev = "50b9dc47028001d5790a3b283ca4cbe9dc98f100" }
+uplc = "1.0.19-alpha"
+pallas-primitives = "0.18.0"
+pallas-codec = "0.18.0"
+getrandom = {  features = ["js"] }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires


### PR DESCRIPTION
I've just found that there was a rust dependency pointing at my private fork. 
Here I removed it. 
Note that this doesn't update the nodejs packages ([apply-args-nodejs](https://www.npmjs.com/package/apply-args-nodejs)). 
The dependencies are synced together and there is nothing interesting in their changelog.

The original [pr](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1325#issue-1495100790) that included the package here as a dependency said: 
```
Will update once we get an official release with fixes in the dependencies (pallas/pallas-primitives and then downstream aiken/uplc).
```